### PR TITLE
fix(github): fix links in ISSUE_TEMPLATE and PULL_REQUEST_TEMPLATE.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 RPGアツマールへの issue ありがとうございます！
 
 issue を提出する前に、以下のガイドラインを確認してください。
-https://github.com/astumaru/api-reference/blob/master/CONTRIBUTING.md
+https://github.com/atsumaru/api-references/blob/master/CONTRIBUTING.md
 
 また、現在アツマールgithubでは既存機能に関するissueのみ受け付けています。
 新規機能の提案などは別途、Twitterやアンケートなどにお願いします。

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 RPGアツマールへの pull request ありがとうございます！
 
 pull request を提出する前に、以下のガイドラインを確認してください。
-https://github.com/astumaru/api-reference/blob/master/CONTRIBUTING.md
+https://github.com/atsumaru/api-references/blob/master/CONTRIBUTING.md
 -->
 
 <!-- 以下に修正内容に関する説明をくわしく記述してください -->


### PR DESCRIPTION
### 概要
- https://github.com/atsumaru/api-references/issues/5 にてご指摘いただいた内容の修正です。
- 本来、リポジトリの `CONTRIBUTING.md` へのリンクを貼る予定でしたが、正しいリンクが記載されていませんでした。