### PR TITLE
fix(references): 非同期系APIの項目を統一・一部情報を補足

### DIFF
--- a/content/collections/apis/comment.md
+++ b/content/collections/apis/comment.md
@@ -63,7 +63,7 @@ contextfactor は「セリフ」コマンドと「選択肢」コマンドで、
 APIを利用したコメント機能の利用
 
 #### シーン設定API
-メソッド | window.RPGAtsumaru.comment.changeScene(sceneName)
+メソッド | `window.RPGAtsumaru.comment.changeScene(sceneName: string)`
 :---|:---
 説明 | <ul><li>コメントシステムのシーンを設定する。</li><li>シーンが切り替わると、そのシーンのコメント空間に切り替わる。</li><li>ツクールでは基本的にマップID=シーン名となる。</li><li>サーバーアクセスが発生する。（ただし直近5つのsceneはキャッシュされ、再アクセスには発生しない）</li><li>シーン名は64文字までのascii限定。</li></ul><br>※なお、アンダースコア２つで始まるシーン名は特殊用途として予約されています。<br>予約されている中で現在利用可能なシーン名は `__title` と `__gameover` の2つで、 `__title` は内部状態の初期値になっています。
 引数 | シーン名を表す文字列
@@ -72,7 +72,7 @@ APIを利用したコメント機能の利用
 更新日 | 2018/10/25
 
 #### シーン切り替えAPI
-メソッド | window.RPGAtsumaru.comment.resetAndChangeScene(sceneName)
+メソッド | `window.RPGAtsumaru.comment.resetAndChangeScene(sceneName: string)`
 :---|:---
 説明 | <ul><li>changeSceneと違い、context(contextfactorとminorcontext)による内部状態をリセットしつつシーンを切り替える</li><li>サーバーアクセスが発生する。（ただし直近5つのsceneはキャッシュされ、再アクセスには発生しない）</li><li>ツクール製ゲームではタイトルとゲームオーバーで全員同じコメントが流れる機能のために使用しています。</li></ul>
 引数 | シーン名を表す文字列
@@ -81,7 +81,7 @@ APIを利用したコメント機能の利用
 更新日 | 2018/10/25
 
 #### コンテキストファクターAPI
-メソッド | window.RPGAtsumaru.comment.pushContextFactor(factor)
+メソッド | `window.RPGAtsumaru.comment.pushContextFactor(factor: string)`
 :---|:---
 説明 | <ul><li>コメントシステムにContextFactorとなる値(ツクールでいうセリフと選択肢)をpushして、contextを更新する。</li><li>contextが更新されたことでgposが更新され、文脈にあわせたコメントが流れる。</li><li>また、minorcontextを初期化する。</li></ul>
 引数 | コメントシステムにpushするコンテキストを表す文字列
@@ -90,7 +90,7 @@ APIを利用したコメント機能の利用
 更新日 | 2018/10/25
 
 #### マイナーコンテキストAPI
-メソッド | window.RPGAtsumaru.comment.pushMinorContext()
+メソッド | `window.RPGAtsumaru.comment.pushMinorContext()`
 :---|:---
 説明 | <ul><li>コメントシステムのgposを更新する。</li><li>contextが更新されたことでgposKeyが更新され、文脈にあわせたコメントが流れる。</li><li>内部的にminorcontext値を持っており、それを+1することでgposを更新している。pushContextFactorを使うと、minorcontext値は初期値に戻される。</li><li>MinorContextは「ContextFactorのさらに細かい状態」を想定している。</li><li>ツクールではエンジンにwaitがかかるような命令で使用している。</li></ul>
 引数 | 無し
@@ -99,7 +99,7 @@ APIを利用したコメント機能の利用
 更新日 | 2018/10/25
 
 #### コンテキストAPI
-メソッド |window.RPGAtsumaru.comment.setContext(context)
+メソッド | `window.RPGAtsumaru.comment.setContext(context: string)`
 :---|:---
 説明 | <ul><li>pushContextFactorと違い、contextを引数に渡した値で直接書き換える。</li><li>特定のScene内でまったく同じゲーム状態を厳密に作りたい場合に使う。</li><li>このときの context の値は、ascii 64文字以下推奨。</li></ul>
 引数 | コンテキスト値を表す文字列
@@ -108,46 +108,46 @@ APIを利用したコメント機能の利用
 更新日 | 2018/10/25
 
 #### 表示コメント取得API
-メソッド |window.RPGAtsumaru.comment.cameOut.subscribe(observer)
+メソッド | `window.RPGAtsumaru.comment.cameOut.subscribe(observer: Observer)`
 :---|:---
 説明 | <ul><li>ゲーム画面に流れるコメントを取得できるAPIです。</li><li>表示前のコメントは取得できません。</li><li>Observer, subscriptionについてはESNextのObservableを参照してください。</li></ul>
-引数 | RPGアツマールのコメント情報({command: string, content: string}[])を受け取るObserver
-戻り値 | subscription
+引数 | RPGアツマールのコメント情報( `{command: string, content: string}[]` )を受け取るObserver
+戻り値 | `subscription`
 リリース日 | 2017/07/27
 更新日 | 2018/11/25
 
 #### 表示コメント取得コールバックAPI
-メソッド |window.RPGAtsumaru.comment.cameOut.subscribe(next)
+メソッド | `window.RPGAtsumaru.comment.cameOut.subscribe(next: (comment: {command: string, content: string}[]) => void)`
 :---|:---
 説明 | `window.RPGAtsumaru.comment.cameOut.subscribe(observer)` の引数に、コールバック関数を受け付けられるようにしたものです。
-引数 | RPGアツマールのコメント情報({command: string, content: string}[])を受け取るコールバック
-戻り値 | subscription
+引数 | RPGアツマールのコメント情報( `{command: string, content: string}[]` )を受け取るコールバック
+戻り値 | `subscription`
 リリース日 | 2017/07/27
 更新日 | 2018/11/25
 
 #### 入力コメント取得API
-メソッド |window.RPGAtsumaru.comment.posted.subscribe(observer)
+メソッド | `window.RPGAtsumaru.comment.posted.subscribe(observer: Observer)`
 :---|:---
 説明 | <ul><li>ユーザが投稿したコメント情報を取得できるAPIです。</li><li>Observer, subscriptionについてはESNextのObservableを参照してください。</li></ul>
-引数 | RPGアツマールのコメント情報({command: string, content: string})を受け取るObserver
-戻り値 | subscription
+引数 | RPGアツマールのコメント情報( `{command: string, content: string}` )を受け取るObserver
+戻り値 | `subscription`
 リリース日 | 2017/07/27
 更新日 | 2018/11/25
 
 #### 入力コメント取得コールバックAPI
-メソッド |window.RPGAtsumaru.comment.posted.subscribe(next)
+メソッド | `window.RPGAtsumaru.comment.posted.subscribe(next: (comment: {command: string, content: string}) => void)`
 :---|:---
 説明 | `window.RPGAtsumaru.comment.posted.subscribe(observer)` の引数に、コールバック関数を受け付けられるようにしたものです。
-引数 | RPGアツマールのコメント情報({command: string, content: string})を受け取るコールバック
-戻り値 | subscription
+引数 | RPGアツマールのコメント情報( `{command: string, content: string}` )を受け取るコールバック
+戻り値 | `subscription`
 リリース日 | 2017/07/27
 更新日 | 2018/11/25
 
 #### verboseモードAPI
-変数 |window.RPGAtsumaru.comment.verbose
+変数 | `window.RPGAtsumaru.comment.verbose`
 :---|:---
 説明 | trueをセットすると、コメントのgpos(game position)計算の内部情報をコンソールに出力します
-型 | boolean
+型 | `boolean`
 リリース日 | 2017/09/19
 更新日 | 2018/11/25
 

--- a/content/collections/apis/common/errors.md
+++ b/content/collections/apis/common/errors.md
@@ -22,7 +22,7 @@ interface AtsumaruApiError {
 
 code一覧 | 解説
 :---|:---
-BAD_REQUEST | ゲーム側で何かしらAPIの使い方を間違えている場合のコードです
+BAD_REQUEST | ゲーム側でなんらかのAPIの使い方を間違えている場合のコードです。例えば、メソッドの引数の型を間違えている場合に発生します。
 UNAUTHORIZED | プレイヤーが[ログイン](/common/login)している必要があるAPIを、プレイヤーが非ログイン状態で使った場合のコードです
 API_CALL_LIMIT_EXCEEDED | [APIの呼び出し回数制限](/common/rate-limit) の上限に達した際に返されるコードです
 FORBIDDEN | 次のように、プレイヤーやゲームがAPIに対してアクセス権限がない場合に発生します。<ul><li>ユーザーIDを指定するAPIで、対象のユーザー情報を取得する権限がない場合(相手のユーザーのプレイヤー通信有効化がされていないなど)</li><li>ゲームIDを指定するAPIで、対象のゲーム情報を取得する権限がない場合(対象のゲームが非公開であるなど)</li></ul>
@@ -32,7 +32,7 @@ INTERNAL_SERVER_ERROR | サーバー側で何らかの問題が発生してい�
 ### コード例
 
 ```js
-window.RPGAtsumaru.experimental.scoreboards.setRecord(board_id, score)
+window.RPGAtsumaru.experimental.scoreboards.setRecord(boardId, score)
   .catch(function(err) {
     switch(err.code) {
       case "BAD_REQUEST":

--- a/content/collections/apis/common/interplayer.md
+++ b/content/collections/apis/common/interplayer.md
@@ -64,3 +64,10 @@ APIを利用したプレイヤー間通信の有効化
 戻り値 | `Promise<void>`
 リリース日 | 2018/12/17
 更新日 | 2018/12/17
+
+##### 起こりうるエラーの種類
+名前 | 説明
+:---|:---
+[UNAUTHORIZED](/common/errors) | プレイヤーがログインしていない
+[INTERNAL_SERVER_ERROR](/common/errors) | RPGアツマールのサービス側で何らかの問題が発生しているか、または通信に失敗した
+[API_CALL_LIMIT_EXCEEDED](/common/errors) | 短時間にゲームAPIを利用しすぎて、一時的に利用を制限されている

--- a/content/collections/apis/controller.md
+++ b/content/collections/apis/controller.md
@@ -35,19 +35,19 @@ RPGツクールMV製ゲームの場合、RPGアツマールが挿入する `rpga
 APIを利用したコントローラー機能の利用
 
 #### コントローラー入力取得API
-メソッド | window.RPGAtsumaru.controllers.defaultController.subscribe(observer)
+メソッド | `window.RPGAtsumaru.controllers.defaultController.subscribe(observer: Observer)`
 :---|:---
 説明 | <ul><li>RPGアツマールのスマホ版にあるコントローラーの入力情報を取得できるAPIです。</li><li>Observer, subscriptionについてはESNextのObservableを参照してください。</li></ul>
-引数 | RPGアツマールのコントローラーの入力情報({type: string, key: string})を受け取るObserver
-戻り値 | subscription
+引数 | RPGアツマールのコントローラーの入力情報( `{type: string, key: string}` )を受け取るObserver
+戻り値 | `subscription`
 リリース日 | 2016/12/27
 更新日 | 2018/10/25
 
 #### コントローラー入力取得コールバックAPI
-メソッド | window.RPGAtsumaru.controllers.defaultController.subscribe(next)
+メソッド | `window.RPGAtsumaru.controllers.defaultController.subscribe(next: (info: {type: string, key: string}) => void)`
 :---|:---
 説明 | `window.RPGAtsumaru.controllers.defaultController.subscribe(observer)` の引数に、コールバック関数を受け付けられるようにしたものです。
-引数 | RPGアツマールのコントローラー入力情報({type: string, key: string})を受け取るコールバック
-戻り値 | subscription
+引数 | RPGアツマールのコントローラー入力情報( `{type: string, key: string}` )を受け取るコールバック
+戻り値 | `subscription`
 リリース日 | 2016/12/27
 更新日 | 2018/10/25

--- a/content/collections/apis/copy-query.md
+++ b/content/collections/apis/copy-query.md
@@ -62,7 +62,7 @@ CopyQuery 10 11 12
 APIを利用したquery情報取得方法
 
 ####  query情報取得API
-メソッド | window.RPGAtsumaru.experimental.query[key]
+メソッド | `window.RPGAtsumaru.experimental.query[key]`
 :---|:---
 説明 | 引数のkeyに指定した文字列のquery情報を取得します。
 引数 | query名を表す文字列

--- a/content/collections/apis/creator-modal.md
+++ b/content/collections/apis/creator-modal.md
@@ -75,9 +75,9 @@ DisplayCreatorInformationModal 64341294
 APIを利用した作者情報の設置方法
 
 #### 作者情報API
-メソッド | window.RPGAtsumaru.experimental.popups.displayCreatorInformationModal(niconico_user_id)
+メソッド | `window.RPGAtsumaru.experimental.popups.displayCreatorInformationModal(niconicoUserId?: number &#124; null)`
 :---|:---
-説明 | 引数のniconico_user_idにniconicoユーザIDをint値で渡すことにより、作者情報ダイアログを表示するメソッド。<br>引数に渡す文字列の形式は整数で、省略(null)も可能。省略した場合は実行しているゲームの作者情報を表示。
+説明 | 引数の `niconicoUserId` にniconicoユーザIDをint値で渡すことにより、作者情報ダイアログを表示するメソッド。<br>引数に渡す文字列の形式は整数で、省略(null)も可能。省略した場合は実行しているゲームの作者情報を表示。
 引数 | niconicoユーザID(整数)。またはnull
 戻り値 | `Promise<void>`
 リリース日 | 2018/07/02

--- a/content/collections/apis/global-sever-variable/api.md
+++ b/content/collections/apis/global-sever-variable/api.md
@@ -12,7 +12,7 @@ APIを使ったグローバルサーバー変数の利用方法について解�
 
 グローバルサーバー変数のIDを指定し、現在値、最大値、最小値、変数名を取得します。
 
-メソッド | `window.RPGAtsumaru.experimental.globalServerVariable.getGlobalServerVariable(globalServerVariableId)`
+メソッド | `window.RPGAtsumaru.experimental.globalServerVariable.getGlobalServerVariable(globalServerVariableId: number)`
 :---|:---
 説明 | 引数に指定した globalServerVariableId のグローバルサーバー変数の情報を取得する
 引数 | グローバルサーバー変数ID (自然数) ※[グローバルサーバー変数設定画面](/global-server-variable/setting)で設定
@@ -20,36 +20,65 @@ APIを使ったグローバルサーバー変数の利用方法について解�
 リリース日 | 2018/12/17
 更新日 | 2018/12/17
 
-### GlobalServerVariableDataオブジェクトについて
-名前 | 型 | 説明
+### 戻り値の型 GlobalServerVariableData について
+戻り値で取得できる `GlobalServerVariableData` は以下のような型です。
+
+```js
+interface GlobalServerVariableData {
+  name: string,
+  maxValue: number,
+  minValue: number,
+  value: number
+}
+```
+
+プロパティの内容は次のようになっています。
+
+プロパティ名 | 型 | 内容
 :---|:---|:---
-value | number | グローバルサーバー変数の現在値
-minValue | number | グローバルサーバー変数の最小値
-maxValue | number | グローバルサーバー変数の最大値
-name | string | グローバルサーバー変数の変数名
+value | `number` | グローバルサーバー変数の現在値
+minValue | `number` | グローバルサーバー変数の最小値
+maxValue | `number` | グローバルサーバー変数の最大値
+name | `string` | グローバルサーバー変数の変数名
+
+### 戻り値の例
+
+```js
+// window.RPGAtsumaru.experimental.globalServerVariable.getGlobalServerVariable(1).then(function(v) { console.log(v) }) を実行
+{
+  "name": "レイドボスHP",
+  "maxValue": 10000,
+  "minValue": 0,
+  "value": 1234
+}
+```
 
 ### 起こりうるエラーの種類
 名前 | 説明
 :---|:---
-BAD_REQUEST | 指定したグローバルサーバー変数IDがそのゲームのものではない
-INTERNAL_SERVER_ERROR | RPGアツマールのサービス側で何らかの問題が発生しているか、または通信に失敗した
-API_CALL_LIMIT_EXCEEDED | 短時間にRPGアツマール ゲームAPIを利用しすぎて、一時的に利用を制限されている
+[BAD_REQUEST](/common/errors) | <ul><li>指定したグローバルサーバー変数IDがそのゲームのものではない</li><li>引数として不正な値を指定している</li></ul>
+[INTERNAL_SERVER_ERROR](/common/errors) | RPGアツマールのサービス側で何らかの問題が発生しているか、または通信に失敗した
+[API_CALL_LIMIT_EXCEEDED](/common/errors) | 短時間にRPGアツマール ゲームAPIを利用しすぎて、一時的に利用を制限されている
+
 
 ## トリガー発動
 
 予め設定したトリガーIDを指定して、グローバルサーバー変数の値を変化させます。
 
-メソッド | `window.RPGAtsumaru.experimental.globalServerVariable.triggerCall(triggerId)`
+メソッド | `window.RPGAtsumaru.experimental.globalServerVariable.triggerCall(triggerId:number, delta?: number)`
 :---|:---
 説明 | 引数に指定したtriggeridのトリガーを発動させる
-引数 | トリガーID (自然数) ※[グローバルサーバー変数設定画面](/global-server-variable/setting)で設定
+引数 | <ul><li>`triggerId`: トリガーID (自然数) ※[グローバルサーバー変数設定画面](/global-server-variable/setting)で設定</li><li>`delta`: 変数を増減させる値 (「ゲーム内で増減値を指定して実行」トリガーの場合のみ指定可能)</li></ul>
 戻り値 | `Promise<void>`
 リリース日 | 2018/12/17
 更新日 | 2018/12/17
 
+ - 引数 `delta` はトリガーの種別が「ゲーム内で増減値を指定して実行」のときのみ指定可能です。
+  -「ゲーム内から実行」トリガーの場合は指定しないでください。
+
 ### 起こりうるエラーの種類
 名前 | 説明
 :---|:---
-BAD_REQUEST | 指定したトリガーIDがそのゲームのものではない
-INTERNAL_SERVER_ERROR | RPGアツマールのサービス側で何らかの問題が発生しているか、または通信に失敗した
-API_CALL_LIMIT_EXCEEDED | 短時間にゲームAPIを利用しすぎて、一時的に利用を制限されている
+[BAD_REQUEST](/common/errors) | <ul><li>指定したトリガーIDがそのゲームのものではない</li><li>「ゲーム内から実行」トリガーで `delta` を指定した</li><li>「ゲーム内で増減値を指定して実行」トリガーで `delta` を省略した</li><li>引数として不正な値を指定している</li></ul>
+[INTERNAL_SERVER_ERROR](/common/errors) | RPGアツマールのサービス側で何らかの問題が発生しているか、または通信に失敗した
+[API_CALL_LIMIT_EXCEEDED](/common/errors) | 短時間にゲームAPIを利用しすぎて、一時的に利用を制限されている

--- a/content/collections/apis/popup.md
+++ b/content/collections/apis/popup.md
@@ -67,7 +67,7 @@ OpenLink https://game.nicovideo.jp/atsumaru
 APIを利用した外部リンク設置方法
 
 #### 外部リンク表示API
-メソッド | window.RPGAtsumaru.popups.openLink(openLink_url)
+メソッド | `window.RPGAtsumaru.popups.openLink(openLinkUrl: string)`
 :---|:---
 説明 | 引数のopenLink_urlにリンク先を表す特定の文字列を渡すことにより、外部リンクを記載したダイアログを表示するメソッド。<br>引数に渡す文字列の形式は `OpenLink http://example.com/` (url部分は任意のURLに置き換え)
 引数 | リンクの値を表す文字列

--- a/content/collections/apis/scoreboard/api.md
+++ b/content/collections/apis/scoreboard/api.md
@@ -6,52 +6,131 @@ order: 3
 experimental: true
 ---
 
-### APIでの利用方法
-APIを使ったスコアボードの利用方法
+## APIでの利用方法
+APIを使ったスコアボードの利用方法についてです。
 
-#### スコアボードへの記録
-メソッド | window.RPGAtsumaru.experimental.scoreboards.setRecord(board_id, score)
+## スコアボードへの記録
+メソッド | `window.RPGAtsumaru.experimental.scoreboards.setRecord(boardId: number, score: number)`
 :---|:---
-説明 | 引数のboard_idを指定することによりスコアを記録するスコアボードを指定。<br>第2引数のscoreでスコアを指定し、記録するスコアの点数を記録。
-引数 | <ul><li>スコアボードID(デフォルトは1〜10までの整数)</li><li>記録するスコアの点数。スコアの値としてRPGアツマールがサポートしている範囲は -999,999,999,999,999 ～ +999,999,999,999,999 です。</li></ul>
+説明 | 引数の `boardId` を指定することによりスコアを記録するスコアボードを指定。<br>第2引数のscoreでスコアを指定し、記録するスコアの点数を記録。
+引数 | <ul><li>スコアボードID(デフォルトは1〜10までの整数)</li><li>記録するスコアの点数。スコアの値としてRPGアツマールがサポートしている範囲は `-999,999,999,999,999` ～ `+999,999,999,999,999` です。</li></ul>
 戻り値 | `Promise<void>`
 リリース日 | 2018/06/15
 更新日 | 2018/08/28
 
-
-#### スコアボードを表示する
-メソッド | window.RPGAtsumaru.experimental.scoreboards.display(board_id)
+### 起こりうるエラーの種類
+名前 | 説明
 :---|:---
-説明 | 引数のboard_idを指定することによりスコアを記録するスコアボードを指定してスコアボード表示
+[BAD_REQUEST](/common/errors) | <ul><li>`bordId` に[スコアボード設定画面](/scoreboard/api)で設定している範囲外の値を指定した</li><li>引数として不正な値を指定している</li></ul>
+[INTERNAL_SERVER_ERROR](/common/errors) | RPGアツマールのサービス側で何らかの問題が発生しているか、または通信に失敗した
+
+
+## スコアボードを表示する
+メソッド | `window.RPGAtsumaru.experimental.scoreboards.display(boardId: number)`
+:---|:---
+説明 | 引数の `boardId` を指定することによりスコアを記録するスコアボードを指定してスコアボード表示
 引数 | スコアボードID(デフォルトは1〜10までの整数)
 戻り値 | `Promise<void>`
 リリース日 | 2018/06/15
 更新日 | 2018/06/15
 
-#### スコアボードからデータを読み込み
-メソッド | window.RPGAtsumaru.experimental.scoreboards.getRecords(board_id)
+
+## スコアボードからデータを読み込み
+メソッド | `window.RPGAtsumaru.experimental.scoreboards.getRecords(boardId: number)`
 :---|:---
-説明 | 引数のboard_idを指定することによりスコアボードの情報を取得
+説明 | 引数の `boardId` を指定することによりスコアボードの情報を取得
 引数 | スコアボードID(デフォルトは1〜10までの整数)
 戻り値 | `Promise<ScoreboardData>`
 リリース日 | 2018/06/15
 更新日 | 2018/06/15
 
-##### ScoreboardDataオブジェクトについて
-名前 | 型 | 説明
+
+### 戻り値の型 ScoreboardData について
+
+戻り値で取得できる `ScoreboardData` は以下のような型です。
+
+```js
+interface ScoreboardData {
+  myRecord: null | {
+    isNewRecord: boolean,
+    rank: number,
+    score: number
+  },
+  ranking: Array<{
+    rank: number,
+    score: number,
+    userName: string
+  }>,
+  myBestRecord: null | {
+    rank: number,
+    score: number,
+    userName: string
+  },
+  boardId: number,
+  boardName: string
+}
+```
+
+プロパティの内容は次のようになっています。
+
+プロパティ名 | 型 | 内容
 :---|:---|:---
-boardId | number | ボードID
-boardName | string | ボードの名前
-myRecord | object or null | 今回の自己レコード
-myRecord.rank | number | 今回の自己レコードのランキング順位
-myRecord.score | number | 今回の自己レコードのスコア
-myRecord.isNewRecord | boolean | 今回の自己レコードが自己新記録かどうか
-myBestRecord | object or null | 自己ベスト記録。ログインしていないと必ずnullになる
-myBestRecord.rank | number | 自己ベスト記録のランキング順位
-myBestRecord.userName | string | 自己ベスト記録のユーザ名
-myBestRecord.score | number | 自己ベスト記録のスコア
-ranking | array | ランキングデータ
-ranking.length | number | ランキングデータの長さ
-ranking[n].rank | number | n+1番目のランキング
-ranking[n].userName | string | n+1番目のランクのユーザ名
-ranking[n].score | number | n+1番目のランクのスコア
+boardId | `number` | ボードID
+boardName | `string` | ボードの名前
+myRecord | `object &#124; null` | 今回の自己レコード
+myRecord.rank | `number` | 今回の自己レコードのランキング順位
+myRecord.score | `number` | 今回の自己レコードのスコア
+myRecord.isNewRecord | `boolean` | 今回の自己レコードが自己新記録かどうか
+myBestRecord | `object &#124; null` | 自己ベスト記録。ログインしていないと必ずnullになる
+myBestRecord.rank | `number` | 自己ベスト記録のランキング順位
+myBestRecord.userName | `string` | 自己ベスト記録のユーザ名
+myBestRecord.score | `number` | 自己ベスト記録のスコア
+ranking | `array` | ランキングデータ
+ranking.length | `number` | ランキングデータの長さ
+ranking[n].rank | `number` | n+1番目のランキング
+ranking[n].userName | `string` | n+1番目のランクのユーザ名
+ranking[n].score | `number` | n+1番目のランクのスコア
+
+### 戻り値の例
+
+```js
+// window.RPGAtsumaru.experimental.scoreboards.getRecords(1).then(function(v) { console.log(v) }) を実行
+{
+  "myRecord": {
+    "isNewRecord": false,
+    "rank": 5,
+    "score": 0
+  },
+  "ranking": [
+    {
+      "rank": 1,
+      "score": 1000,
+      "userName": "atsumalion"
+    },
+    {
+      "rank": 2,
+      "score": 500,
+      "userName": "atsumatiger"
+    },
+    {
+      "rank": 3,
+      "score": 100,
+      "userName": "atsumagorilla"
+    }
+  ],
+  "myBestRecord": {
+    "rank": 1,
+    "score": 1000,
+    "userName": "atsumalion"
+  },
+  "boardId": 1,
+  "boardName": "スコアボードの名前"
+}
+```
+
+
+### 起こりうるエラーの種類
+名前 | 説明
+:---|:---
+[BAD_REQUEST](/common/errors) | <ul><li>`bordId` に[スコアボード設定画面](/scoreboard/api)で設定している範囲外の値を指定した</li><li>引数として不正な値を指定している</li></ul>
+[INTERNAL_SERVER_ERROR](/common/errors) | RPGアツマールのサービス側で何らかの問題が発生しているか、または通信に失敗した

--- a/content/collections/apis/screenshot.md
+++ b/content/collections/apis/screenshot.md
@@ -61,7 +61,7 @@ DisplayScreenshotModal
 APIを利用したスクリーンショットの利用方法
 
 #### スクリーンショットAPI
-メソッド | window.RPGAtsumaru.experimental.screenshot.displayModal();
+メソッド | `window.RPGAtsumaru.experimental.screenshot.displayModal()`
 :---|:---
 説明 | このメソッドを呼び出した時点でのスクリーンショットを撮影し、Twitterに投稿するダイアログを表示します
 引数 | なし
@@ -69,11 +69,11 @@ APIを利用したスクリーンショットの利用方法
 リリース日 | 2018/10/01
 更新日 | 2018/10/01
 
-### スクリーンショット画像差し替えAPI
-メソッド | window.RPGAtsumaru.experimental.screenshot.setScreenshotHandler(handler);
+#### スクリーンショット画像差し替えAPI
+メソッド | `window.RPGAtsumaru.experimental.screenshot.setScreenshotHandler(handler: () => Promise<string>)`
 :---|:---
 説明 | スクリーンショットの内容を差し替えるハンドラを登録します。複数回登録した場合は最後の関数だけ有効になります
 引数 | `() => Promise<string>` 型の関数。戻り値の文字列はjpegまたはpng形式かつ `data-url` な画像文字列
-戻り値 | void
+戻り値 | `void`
 リリース日 | 2018/11/22
 更新日 | 2018/11/22

--- a/content/collections/apis/shared-save.md
+++ b/content/collections/apis/shared-save.md
@@ -71,21 +71,46 @@ experimental: true
 メソッド | `window.RPGAtsumaru.experimental.storage.getSharedItems(userIds: number[], gameId?: number)`
 :---|:---
 説明 | 指定したユーザの `Atsumaru Shared` というキーで保存したセーブデータを取得する。
-引数 | <ul><li>`userIds` : ユーザー情報を取得したいユーザーのニコニコユーザーIDの配列を自然数で、最大100件まで指定します。</li><li>`gameId` : 現在プレイ中のゲーム以外からセーブデータを取得する場合、ゲームのIDを自然数で指定します。</li></ul>
-戻り値 | `Promise<{ [userId: number]: string }>`
+引数 | <ul><li>`userIds` : 共有セーブを取得したいユーザーのニコニコユーザーIDの配列を自然数で、最大100件まで指定します。</li><li>`gameId` : 現在プレイ中のゲーム以外からセーブデータを取得する場合、ゲームのIDを自然数で指定します。</li></ul>
+戻り値 | `Promise<SharedSaveItems>`
 リリース日 | 2018/12/17
 更新日 | 2018/12/17
 
 - `userIds` で指定したユーザーのセーブデータユーザーのデータを取得できます。
 - 第二引数の `gameId` を指定することで、別のゲームの共有セーブを取得できます。
 
+##### 戻り値の型 SharedSaveItems について
+
+戻り値で取得できる `SharedSaveItems` は以下のような型です。
+
+```js
+interface SharedSaveItems {
+  [userId: number]: string;
+}
+```
+
+プロパティの内容は次のようになっています。
+
+プロパティ名 | 型 | 内容
+:---|:---|:---
+[userId: number] | `string` | `userId` のIDのユーザーの共有セーブデータを収納します。
+
+
 ##### 戻り値の例
 
 ```js
-// window.RPGAtsumaru.experimental.storage.getSharedItems([123, 456, 789]) を実行
+// window.RPGAtsumaru.experimental.storage.getSharedItems([123, 456, 789]).then(function(v) { console.log(v) }) を実行
 {
   123: "ユーザー123の共有データ",
   456: "ユーザー456の共有データ"
   // 789 のユーザーが取得先のゲームで「プレイヤー間通信の有効化」されていない場合は結果に含まれません！
 }
 ```
+
+##### 起こりうるエラーの種類
+名前 | 説明
+:---|:---
+[BAD_REQUEST](/common/errors) | 引数として不正な値を指定している
+[FORBIDDEN](/common/errors) | `gameId` にアクセス不能なゲームのIDを指定した場合
+[INTERNAL_SERVER_ERROR](/common/errors) | RPGアツマールのサービス側で何らかの問題が発生しているか、または通信に失敗した
+[API_CALL_LIMIT_EXCEEDED](/common/errors) | 短時間にゲームAPIを利用しすぎて、一時的に利用を制限されている

--- a/content/collections/apis/signal.md
+++ b/content/collections/apis/signal.md
@@ -65,6 +65,15 @@ experimental: true
   - グローバルシグナルはゲームあたり1,000件まで保存されます。
 
 
+##### 起こりうるエラーの種類
+名前 | 説明
+:---|:---
+[UNAUTHORIZED](/common/errors) | プレイヤーがログインしていない
+[BAD_REQUEST](/common/errors) | <ul><li>`data` に100byte以上の文字列を指定した</li><li>引数として不正な値を指定している</li></ul>
+[INTERNAL_SERVER_ERROR](/common/errors) | RPGアツマールのサービス側で何らかの問題が発生しているか、または通信に失敗した
+[API_CALL_LIMIT_EXCEEDED](/common/errors) | 短時間にゲームAPIを利用しすぎて、一時的に利用を制限されている
+
+
 #### グローバルシグナルの取得
 
 メソッド | `window.RPGAtsumaru.experimental.signal.getGlobalSignals()`
@@ -94,19 +103,19 @@ interface GlobalSignal {
 
 プロパティの内容は次のようになっています。
 
-プロパティ名 | 内容
+プロパティ名 | 型 | 内容
 :---|:---
-id | シグナルそれぞれでユニークなID値
-senderId | シグナルを送信したユーザーのニコニコユーザーID
-senderName | シグナルを送信したユーザーのユーザー名
-data | 送信したシグナル文字列
-createdAt | シグナルが送信された日時。すでに処理済みのシグナルを判別するために用います。
+id | `number` | シグナルそれぞれでユニークなID値
+senderId | `number` | シグナルを送信したユーザーのニコニコユーザーID
+senderName | `string` | シグナルを送信したユーザーのユーザー名
+data | `string` | 送信したシグナル文字列
+createdAt | `number` | シグナルが送信された日時(秒単位のunix timestamp)。すでに処理済みのシグナルを判別するために用います。
 
 
 ##### 戻り値の例
 
 ```js
-// window.RPGAtsumaru.experimental.storage.getGlobalSignals() を実行
+// window.RPGAtsumaru.experimental.storage.getGlobalSignals().then(function(v) { console.log(v) }) を実行
 [
   {
     createdAt: 1543397700,
@@ -126,11 +135,17 @@ createdAt | シグナルが送信された日時。すでに処理済みのシ�
 ```
 
 
+##### 起こりうるエラーの種類
+名前 | 説明
+:---|:---
+[INTERNAL_SERVER_ERROR](/common/errors) | RPGアツマールのサービス側で何らかの問題が発生しているか、または通信に失敗した
+[API_CALL_LIMIT_EXCEEDED](/common/errors) | 短時間にゲームAPIを利用しすぎて、一時的に利用を制限されている
+
 #### ユーザーシグナルの送信
 
 メソッド | `window.RPGAtsumaru.experimental.signal.sendSignalToUser(receiverId: number, data: string)`
 :---|:---
-説明 | ゲームのグローバルシグナルとして `data` で指定した文字列を送信します。
+説明 | ユーザーシグナルとして `receiverId` で指定したユーザーIDのユーザーに `data` で指定した文字列を送信します。
 引数 | <ul><li>`receiverId` : 送信先のニコニコユーザーIDを指定します。</li><li>`data` : シグナルとして、任意の文字列を100byte以内で送信できます。</li></ul>
 戻り値 | `Promise<void>`
 リリース日 | 2018/12/17
@@ -141,6 +156,15 @@ createdAt | シグナルが送信された日時。すでに処理済みのシ�
   - また、ゲームあたり1ユーザー10KBまでとなります。
     - ゲームからのシグナル送信によって、古いシグナルから消えていきます。
     - 他のゲームからのシグナル送信によっても消える可能性があります。
+
+##### 起こりうるエラーの種類
+名前 | 説明
+:---|:---
+[UNAUTHORIZED](/common/errors) | プレイヤーがログインしていない
+[FORBIDDEN](/common/errors) | `userId` に[プレイヤー間通信の有効化](/common/interplayer)を行っていないユーザーのIDを指定した
+[BAD_REQUEST](/common/errors) | <ul><li>`data` に100byte以上の文字列を指定した</li><li>引数として不正な値を指定している</li></ul>
+[INTERNAL_SERVER_ERROR](/common/errors) | RPGアツマールのサービス側で何らかの問題が発生しているか、または通信に失敗した
+[API_CALL_LIMIT_EXCEEDED](/common/errors) | 短時間にゲームAPIを利用しすぎて、一時的に利用を制限されている
 
 
 #### ユーザーシグナルの取得
@@ -177,17 +201,17 @@ interface UserSignal {
 
 プロパティ名 | 内容
 :---|:---
-id | シグナルそれぞれでユニークなID値
-senderId | シグナルを送信したユーザーのニコニコユーザーID
-senderName | シグナルを送信したユーザーのユーザー名
-data | 送信したシグナル文字列
-createdAt | シグナルが送信された日時。すでに処理済みのシグナルを判別するために用います。
+id | `number` | シグナルそれぞれでユニークなID値
+senderId | `number` | シグナルを送信したユーザーのニコニコユーザーID
+senderName | `string` | シグナルを送信したユーザーのユーザー名
+data | `string` | 送信したシグナル文字列
+createdAt | `number` | シグナルが送信された日時(秒単位のunix timestamp)。すでに処理済みのシグナルを判別するために用います。
 
 
 ##### 戻り値の例
 
 ```js
-// window.RPGAtsumaru.experimental.signal.getUserSignals() を実行
+// window.RPGAtsumaru.experimental.signal.getUserSignals().then(function(v) { console.log(v) }) を実行
 [
   {
     createdAt: 1543397700,
@@ -205,3 +229,10 @@ createdAt | シグナルが送信された日時。すでに処理済みのシ�
   },
 ]
 ```
+
+##### 起こりうるエラーの種類
+名前 | 説明
+:---|:---
+[UNAUTHORIZED](/common/errors) | プレイヤーがログインしていない
+[INTERNAL_SERVER_ERROR](/common/errors) | RPGアツマールのサービス側で何らかの問題が発生しているか、または通信に失敗した
+[API_CALL_LIMIT_EXCEEDED](/common/errors) | 短時間にゲームAPIを利用しすぎて、一時的に利用を制限されている

--- a/content/collections/apis/storage.md
+++ b/content/collections/apis/storage.md
@@ -43,10 +43,10 @@ Stringを保存するシンプルなKVS（Key-Valueストア)になっていま�
 ゲームAPI | 以下の「APIでの利用方法」を参考に、直接APIを呼び出してください
 
 ### APIでの利用方法
-APIを利用したサーバーセーブ機能の利用
+APIを利用したサーバーセーブ機能の利用です。
 
-### サーバーセーブ全件取得API
-メソッド | window.RPGAtsumaru.storage.getItems()
+#### サーバーセーブ全件取得API
+メソッド | `window.RPGAtsumaru.storage.getItems()`
 :---|:---
 説明 | サーバーに保存されているセーブデータを全件取得します。
 引数 | なし
@@ -54,8 +54,8 @@ APIを利用したサーバーセーブ機能の利用
 リリース日 | 2016/12/27
 更新日 | 2018/10/25
 
-### サーバーセーブ保存API
-メソッド | window.RPGAtsumaru.storage.setItems(items)
+#### サーバーセーブ保存API
+メソッド | `window.RPGAtsumaru.storage.setItems(items: {key: string, value: string}[])`
 :---|:---
 説明 | 引数に指定したitemsに対応するセーブデータを保存します。<br>複数端末からのセーブ時に楽観的ロックをしています。A端末とB端末で同時にゲームをプレイしていた場合にAとBがほぼ同時にsetItems()をした場合、先にsetItems()したもののみが受理されます。後のものは一度getItems()で最新のセーブデータを取得した後で受け付けとなります。<br>サーバーアクセスが発生します。
 引数 | 更新する対象のセーブ情報。型は {key: string, value: string}[]
@@ -63,8 +63,16 @@ APIを利用したサーバーセーブ機能の利用
 リリース日 | 2016/12/27
 更新日 | 2018/10/25
 
-### サーバーセーブ削除API
-メソッド | window.RPGAtsumaru.storage.removeItem(key)
+##### 利用例
+
+```js
+window.RPGAtsumaru.storage.setItems([
+  { key: "キー名", value: JSON.stringify(someObject)}
+]);
+```
+
+#### サーバーセーブ削除API
+メソッド | `window.RPGAtsumaru.storage.removeItem(key)`
 :---|:---
 説明 | 指定したセーブデータを削除します。<br>サーバーアクセスが発生します。
 引数 | 削除対象のセーブのキー。型はstring

--- a/content/collections/apis/user.md
+++ b/content/collections/apis/user.md
@@ -103,7 +103,7 @@ GetRecentUsers
 ```
 
 ### APIでの利用方法
-APIを利用したユーザー情報へのアクセス
+APIを利用したユーザー情報へのアクセス方法についてです。
 
 #### 現在ゲームをプレイしているログインユーザーのユーザー情報を取得
 
@@ -115,13 +115,40 @@ APIを利用したユーザー情報へのアクセス
 メソッド | `window.RPGAtsumaru.experimental.user.getSelfInformation()`
 :---|:---
 引数 | なし
-戻り値 | `Promise<{ id: number, name: string, profile: string, twitterId: string, url: string, isPremium: boolean }>`
+戻り値 | `Promise<SelfInformation>`
 リリース日 | 2018/12/17
 更新日 | 2018/12/17
+
+##### 戻り値の型 SelfInformation について
+戻り値で取得できる `SelfInformation` は以下のような型です。
+
+```js
+interface SelfInformation {
+  id: number;
+  name: string;
+  isPremium: boolean;
+  profile: string;
+  twitterId: string;
+  url: string;
+}
+```
+
+プロパティの内容は次のようになっています。
+
+プロパティ名 | 型 | 内容
+:---|:---|:---
+id | `number` | ユーザーのニコニコユーザーID
+name | `string` | ユーザーの名前
+isPremium | `boolean` | ユーザーがニコニコのプレミアム会員かどうか
+profile | `string` | ユーザーのプロフィール文
+twitterId | `string` | ユーザーのtwitterId
+url | `string` | ユーザーのサイトURL
+
 
 ##### 戻り値の例
 
 ```js
+// window.RPGAtsumaru.experimental.user.getSelfInformation().then(function(v) { console.log(v) }) を実行
 {
   id: 64341294,
   name: "RPGアツマール公式",
@@ -132,6 +159,13 @@ APIを利用したユーザー情報へのアクセス
 }
 ```
 
+##### 起こりうるエラーの種類
+名前 | 説明
+:---|:---
+[UNAUTHORIZED](/common/errors) | プレイヤーがログインしていない
+[INTERNAL_SERVER_ERROR](/common/errors) | RPGアツマールのサービス側で何らかの問題が発生しているか、または通信に失敗した
+[API_CALL_LIMIT_EXCEEDED](/common/errors) | 短時間にゲームAPIを利用しすぎて、一時的に利用を制限されている
+
 #### ユーザーIDを指定して特定のユーザー情報を取得
 
 - 引数でユーザーIDを指定し、指定したユーザーの情報を取得します。
@@ -141,13 +175,38 @@ APIを利用したユーザー情報へのアクセス
 メソッド | `window.RPGAtsumaru.experimental.user.getUserInformation(userId: number)`
 :---|:---
 引数 | `userId` : ユーザー情報を取得したいユーザーのニコニコユーザーIDを自然数で指定します。
-戻り値 | `Promise<{ id: number, name: string, profile: string, twitterId: string, url: string }>`
+戻り値 | `Promise<UserInformation>`
 リリース日 | 2018/12/17
 更新日 | 2018/12/17
+
+
+##### 戻り値の型 UserInformation について
+戻り値で取得できる `UserInformation` は以下のような型です。
+
+```js
+interface UserInformation {
+  id: number;
+  name: string;
+  profile: string;
+  twitterId: string;
+  url: string;
+}
+```
+
+プロパティの内容は次のようになっています。
+
+プロパティ名 | 型 | 内容
+:---|:---|:---
+id | `number` | ユーザーのニコニコユーザーID
+name | `string` | ユーザーの名前
+profile | `string` | ユーザーのプロフィール文
+twitterId | `string` | ユーザーのtwitterId
+url | `string` | ユーザーのサイトURL
 
 ##### 戻り値の例
 
 ```js
+// window.RPGAtsumaru.experimental.user.getUserInformation(64341294).then(function(v) { console.log(v) }) を実行
 {
   id: 64341294,
   name: "RPGアツマール公式",
@@ -156,6 +215,15 @@ APIを利用したユーザー情報へのアクセス
   url: "https://game.nicovideo.jp/atsumaru/"
 }
 ```
+
+##### 起こりうるエラーの種類
+名前 | 説明
+:---|:---
+[FORBIDDEN](/common/errors) | `userId` に[プレイヤー間通信の有効化](/common/interplayer)を行っていないユーザーのIDを指定した
+[BAD_REQUEST](/common/errors) | 引数として不正な値を指定している
+[INTERNAL_SERVER_ERROR](/common/errors) | RPGアツマールのサービス側で何らかの問題が発生しているか、または通信に失敗した
+[API_CALL_LIMIT_EXCEEDED](/common/errors) | 短時間にゲームAPIを利用しすぎて、一時的に利用を制限されている
+
 
 #### 現在のゲームを最近プレイしたユーザーの情報の取得
 
@@ -167,13 +235,32 @@ APIを利用したユーザー情報へのアクセス
 メソッド | `window.RPGAtsumaru.experimental.user.getRecentUsers()`
 :---|:---
 引数 | なし
-戻り値 | `Promise<{ id: number, name: string }[]>`
+戻り値 | `Promise<UserIdName[]>`
 リリース日 | 2018/12/17
 更新日 | 2018/12/17
+
+##### 戻り値の型 UserIdName について
+戻り値で取得できる `UserIdName` は以下のような型です。
+
+```js
+interface UserIdName {
+  id: number;
+  name: string;
+}
+```
+
+プロパティの内容は次のようになっています。
+
+プロパティ名 | 型 | 内容
+:---|:---|:---
+id | `number` | ユーザーのニコニコユーザーID
+name | `string` | ユーザーの名前
+
 
 ##### 戻り値の例
 
 ```js
+// window.RPGAtsumaru.experimental.user.getRecentUsers().then(function(v) { console.log(v) }) を実行
 [
   {
     id: 64341294,
@@ -185,3 +272,10 @@ APIを利用したユーザー情報へのアクセス
   }
 ]
 ```
+
+##### 起こりうるエラーの種類
+名前 | 説明
+:---|:---
+[INTERNAL_SERVER_ERROR](/common/errors) | RPGアツマールのサービス側で何らかの問題が発生しているか、または通信に失敗した
+[API_CALL_LIMIT_EXCEEDED](/common/errors) | 短時間にゲームAPIを利用しすぎて、一時的に利用を制限されている
+

--- a/content/collections/apis/volume.md
+++ b/content/collections/apis/volume.md
@@ -38,28 +38,28 @@ RPGツクールMV製でコアスクリプトv1.5.0以上のゲームの場合、
 APIを利用したボリューム機能の利用
 
 #### ボリューム取得API
-メソッド | window.RPGAtsumaru.volume.getCurrentValue()
+メソッド | `window.RPGAtsumaru.volume.getCurrentValue()`
 :---|:---
 説明 | 現在のRPGアツマールのマスターボリューム値を取得する。
 引数 | なし
-戻り値 | 0～1の実数で表されるマスターボリューム
+戻り値 | `number` 0～1の実数で表されるマスターボリューム
 リリース日 | 2017/12/20
 更新日 | 2018/10/25
 
 #### ボリューム変更取得API
-メソッド | window.RPGAtsumaru.volume.changed.subscribe(observer)
+メソッド | `window.RPGAtsumaru.volume.changed.subscribe(observer: Observer)`
 :---|:---
 説明 | <ul><li>RPGアツマールのマスターボリューム情報の変更を取得する。</li><li>Observer, subscriptionについてはESNextのObservableを参照してください。</li></ul>
 引数 | マスターボリューム情報を受け取るObserver
-戻り値 | subscription
+戻り値 | `subscription`
 リリース日 | 2017/12/20
 更新日 | 2018/10/25
 
 #### ボリューム変更時コールバックAPI
-メソッド | window.RPGAtsumaru.volume.changed.subscribe(next)
+メソッド | `window.RPGAtsumaru.volume.changed.subscribe(next: (volume: number) => void)`
 :---|:---
-説明 | window.RPGAtsumaru.volume.changed.subscribe(observer)の引数に、コールバック関数を受け付けられるようにしたもの。
+説明 | `window.RPGAtsumaru.volume.changed.subscribe(observer)` の引数に、コールバック関数を受け付けられるようにしたもの。
 引数 | マスターボリューム情報を受け取るコールバック
-戻り値 | subscription
+戻り値 | `subscription`
 リリース日 | 2016/12/20
 更新日 | 2018/10/25


### PR DESCRIPTION
### 概要

非同期系のアツマールAPI説明の項目を統一しました。

- すべてtypescriptの型宣言でのメソッド表記に変更、および必ずcodeで囲むようにしました。
- 一部引数情報が足りていないところを補足しました。
- すべての戻り値がある非同期APIに戻り値の情報及び戻り値の例を追加しました。
- すべての非同期APIにエラー情報を追加しました。