### PR TITLE
fix(images): 一部画像がリンク切れになることのある不具合を修正

### DIFF
--- a/static.config.js
+++ b/static.config.js
@@ -24,7 +24,7 @@ export default {
   devBasePath: "/",
 
   getRoutes: async () => {
-    const { apis, overview, changelog } = await jdown("content", { renderer });
+    const { apis, overview, changelog } = await jdown("content", { markdown: {renderer} });
 
     // contents を含めるとデータが肥大化するので、除いたものを apiList とし、 navigation 用に各ページに含める
     const apiListSorted = lodash.sortBy(apis, a => a.order || 1).map(({ contents, ...rest }) => rest);


### PR DESCRIPTION
### 概要

- jdownのオプションが不適切で、一部画像のリンクが正しくなくリンク切れになってしまうことがある不具合を修正しました。