### PR TITLE
fix(tweet_message): ツイート内容差し替えAPIのリリース日などを訂正

### DIFF
--- a/content/collections/apis/screenshot.md
+++ b/content/collections/apis/screenshot.md
@@ -46,7 +46,7 @@ RPGアツマール公式プラグイン | [Github](https://github.com/atsumaru/m
 
 公式プラグインで外部リンクを設置するには以下のようにします。
 
-1. プロジェクトのプラグインフォルダに [AtsumaruScreenshotExperimental.js](https://github.com/atsumaru/mv-plugins/blob/master/plugins/AtsumaruScreenshotExperimental.js) を右クリックし「保存」して設置
+1. プロジェクトのプラグインフォルダに [AtsumaruScreenshotExperimental.js](https://raw.githubusercontent.com/atsumaru/mv-plugins/master/plugins/AtsumaruScreenshotExperimental.js) を右クリックし「保存」して設置
 1. プロジェクトのプラグイン設定で `AtsumaruScreenshotExperimental` プラグインをONにする。
 
 #### スクリーンショット撮影＆モーダル表示
@@ -144,8 +144,8 @@ APIを利用したスクリーンショットの利用方法
 説明 | スクリーンショットAPIやカメラボタンでモーダルを表示したときに、最初に表示されているツイート内容を差し替えます
 引数 | `tweetSettings` : 差し替えるツイート内容を指定します。
 戻り値 | `void`
-リリース日 | 2019/05/??
-更新日 | 2019/05/??
+リリース日 | 2019/05/31
+更新日 | 2019/05/31
 
 ##### 引数の型 TweetSettings について
 引数に指定できる `TweetSettings` は以下のような型です。

--- a/content/collections/apis/signal.md
+++ b/content/collections/apis/signal.md
@@ -49,7 +49,7 @@ recommendTheory: true
 
 方法 | 場所
 :---|:---
-公式プラグイン | <ul><li>[グローバルシグナル](https://raw.githubusercontent.com/atsumaru/mv-plugins/master/plugins/AtsumaruGlobalSignalExperimental.js)</li><li>[ユーザーシグナル](https://raw.githubusercontent.com/atsumaru/mv-plugins/master/plugins/AtsumaruUserSignalExperimental.js)</li></ul>
+公式プラグイン | <ul><li>[グローバルシグナル](https://github.com/atsumaru/mv-plugins/blob/master/plugins/AtsumaruGlobalSignalExperimental.js)</li><li>[ユーザーシグナル](https://github.com/atsumaru/mv-plugins/blob/master/plugins/AtsumaruUserSignalExperimental.js)</li></ul>
 ゲームAPI | 以下の「APIでの利用方法」を参考に、直接APIを呼び出してください
 
 ### 公式プラグインの利用方法

--- a/content/collections/apis/user.md
+++ b/content/collections/apis/user.md
@@ -47,7 +47,7 @@ RPGアツマールを使ったことのあるniconicoユーザーの情報を取
 
 方法 | 場所
 :---|:---
-公式プラグイン | <ul><li>[現在ゲームをプレイしているログインユーザーのユーザー情報を取得](https://raw.githubusercontent.com/atsumaru/mv-plugins/master/plugins/AtsumaruGetSelfInformationExperimental.js)</li><li>[ユーザーIDを指定して特定のユーザー情報を取得](https://raw.githubusercontent.com/atsumaru/mv-plugins/master/plugins/AtsumaruGetUserInformationExperimental.js)</li><li>[現在のゲームを最近プレイしたユーザーの情報の取得](https://raw.githubusercontent.com/atsumaru/mv-plugins/master/plugins/AtsumaruGetRecentUsersExperimental.js)</li></ul>
+公式プラグイン | <ul><li>[現在ゲームをプレイしているログインユーザーのユーザー情報を取得](https://github.com/atsumaru/mv-plugins/blob/master/plugins/AtsumaruGetSelfInformationExperimental.js)</li><li>[ユーザーIDを指定して特定のユーザー情報を取得](https://github.com/atsumaru/mv-plugins/blob/master/plugins/AtsumaruGetUserInformationExperimental.js)</li><li>[現在のゲームを最近プレイしたユーザーの情報の取得](https://github.com/atsumaru/mv-plugins/blob/master/plugins/AtsumaruGetRecentUsersExperimental.js)</li></ul>
 ゲームAPI | 以下の「APIでの利用方法」を参考に、直接APIを呼び出してください
 
 ### 公式プラグインの利用方法


### PR DESCRIPTION
### 概要

- ツイート内容差し替えAPIのリリース日を訂正
- スクリーンショットプラグインの入手リンクの誤りを訂正