### PR TITLE
fix(signal): シグナルAPIの誤表記を訂正

### DIFF
--- a/content/collections/apis/signal.md
+++ b/content/collections/apis/signal.md
@@ -186,7 +186,7 @@ createdAt | `number` | シグナルが送信された日時(秒単位のunix tim
 ##### 戻り値の例
 
 ```js
-// window.RPGAtsumaru.experimental.storage.getGlobalSignals().then(function(v) { console.log(v) }) を実行
+// window.RPGAtsumaru.experimental.signal.getGlobalSignals().then(function(v) { console.log(v) }) を実行
 [
   {
     createdAt: 1543397700,


### PR DESCRIPTION
### 概要

- シグナルAPIのグローバルシグナル戻り値の例で、誤字により正常動作しない例になっていたため修正します。